### PR TITLE
Version 0.5.2 for main channel

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-upload_channels:
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,11 +32,9 @@ test:
     - fredapi/tests
   commands:
     - pip check
-    # test_with_proxies required FRED API key, which should be requested on site
-    {% set ignore_tests = " --ignore=fredapi/tests/test_with_proxies.py" %}
-    # mysterious ValueError('I/O operation on closed file.')
-    {% set skip_tests = "test_search" %}
-    - pytest fredapi/tests -v -k "not ({{ skip_tests }})" {{ ignore_tests }}
+    - python -c "from importlib.metadata import version as v; assert v('fredapi')=='{{ version }}'"
+    # test_with_proxies required FRED API key, which should be requested on site, ignore it
+    - python -m unittest discover -s fredapi/tests -p "test_fred.py" -v
 
 about:
   home: https://github.com/mortada/fredapi


### PR DESCRIPTION
fredapi 0.5.2 

**Destination channel:** Defaults

### Links

- [PKG-9463]
- dev_url:        https://github.com/mortada/fredapi/tree/v0.5.2
- conda_forge:    https://github.com/conda-forge/fredapi-feedstock
- pypi:           https://pypi.org/project/fredapi/0.5.2
- pypi inspector: https://inspector.pypi.io/project/fredapi/0.5.2

### Explanation of changes:

- new version number


[PKG-9463]: https://anaconda.atlassian.net/browse/PKG-9463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ